### PR TITLE
wiiu/render: add support for RGB565 and BGR565

### DIFF
--- a/src/render/wiiu/SDL_render_wiiu.c
+++ b/src/render/wiiu/SDL_render_wiiu.c
@@ -252,7 +252,7 @@ SDL_RenderDriver WIIU_RenderDriver =
     .info = {
         .name = "WiiU GX2",
         .flags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE,
-        .num_texture_formats = 15,
+        .num_texture_formats = 16,
         .texture_formats = {
             SDL_PIXELFORMAT_RGBA8888,
             SDL_PIXELFORMAT_RGBX8888,
@@ -261,6 +261,9 @@ SDL_RenderDriver WIIU_RenderDriver =
             SDL_PIXELFORMAT_RGBA4444,
             SDL_PIXELFORMAT_ABGR4444,
             SDL_PIXELFORMAT_BGRA4444,
+
+            SDL_PIXELFORMAT_RGB565,
+            SDL_PIXELFORMAT_BGR565,
 
             SDL_PIXELFORMAT_ARGB1555,
             SDL_PIXELFORMAT_ABGR1555,
@@ -272,7 +275,8 @@ SDL_RenderDriver WIIU_RenderDriver =
             SDL_PIXELFORMAT_BGRX8888,
             SDL_PIXELFORMAT_ABGR8888,
 
-            SDL_PIXELFORMAT_ARGB2101010,
+            /* SDL currently has a dumbass limit of 16 formats, so this has to be commented-out... */
+            /*SDL_PIXELFORMAT_ARGB2101010,*/
         },
         .max_texture_width = 0,
         .max_texture_height = 0,

--- a/src/render/wiiu/SDL_render_wiiu.h
+++ b/src/render/wiiu/SDL_render_wiiu.h
@@ -262,12 +262,12 @@ static inline WIIU_PixFmt WIIU_SDL_GetPixFmt(Uint32 format)
         /* packed16 formats: 565 */
         case SDL_PIXELFORMAT_RGB565: {
             outFmt.fmt = GX2_SURFACE_FORMAT_UNORM_R5_G6_B5;
-            outFmt.compMap = GX2_COMP_MAP(GX2_SQ_SEL_R, GX2_SQ_SEL_G, GX2_SQ_SEL_B, GX2_SQ_SEL_A);
+            outFmt.compMap = GX2_COMP_MAP(GX2_SQ_SEL_B, GX2_SQ_SEL_G, GX2_SQ_SEL_R, GX2_SQ_SEL_1);
             break;
         }
         case SDL_PIXELFORMAT_BGR565: {
             outFmt.fmt = GX2_SURFACE_FORMAT_UNORM_R5_G6_B5;
-            outFmt.compMap = GX2_COMP_MAP(GX2_SQ_SEL_B, GX2_SQ_SEL_G, GX2_SQ_SEL_R, GX2_SQ_SEL_A);
+            outFmt.compMap = GX2_COMP_MAP(GX2_SQ_SEL_R, GX2_SQ_SEL_G, GX2_SQ_SEL_B, GX2_SQ_SEL_1);
             break;
         }
 


### PR DESCRIPTION
Adds native support for RGB565 and BGR565 without going through SDL2's converters. This provides a great performance boost to my Sonic Mania port.